### PR TITLE
* Non SemVer Support

### DIFF
--- a/Editor/GitDependencyResolver.cs
+++ b/Editor/GitDependencyResolver.cs
@@ -19,11 +19,11 @@ namespace Coffee.PackageManager.DependencyResolver
 		
 		static PackageMeta[] GetInstalledPackages()
 		{
-			//return Directory.GetDirectories ("./Library/PackageCache")
-			//	.Concat (Directory.GetDirectories ("./Packages"))
-			//	.Select (PackageMeta.FromPackageDir)    // Convert to PackageMeta
-			//	.Where (x => x != null)                 // Skip null
-			//	.ToArray ();
+			/*return Directory.GetDirectories ("./Library/PackageCache")
+				.Concat (Directory.GetDirectories ("./Packages"))
+				.Select (PackageMeta.FromPackageDir)    // Convert to PackageMeta
+				.Where (x => x != null)                 // Skip null
+				.ToArray ();*/
 			return AssetDatabase.GetAllAssetPaths()
 				.Where(x => x.StartsWith("Packages/", Ordinal) && x.EndsWith("/package.json", Ordinal))
 				.Select(PackageMeta.FromPackageJson)	// Convert to PackageMeta
@@ -55,7 +55,7 @@ namespace Coffee.PackageManager.DependencyResolver
 				// Collect unused pakages.
 				var unusedPackages = autoInstalledPackages
 					.Where (x => Path.GetFileName(x.path).StartsWith (".", Ordinal))         // Directory name starts with '.'. This is 'auto-installed package'
-					.Where (x => !allDependencies.Any (y => y.name == x.name && y.version == x.version))   // No depended from other packages
+					.Where (x => !allDependencies.Any (y => y.name == x.name && (y.version == null || y.version == x.version)))   // No depended from other packages
 					;
 
 				// Uninstall unused packages and re-check.
@@ -86,10 +86,10 @@ namespace Coffee.PackageManager.DependencyResolver
 			// Check all dependencies.
 			foreach (var dependency in dependencies)
 			{
-				// Is the depended package installed already?
-				bool isInstalled = installedPackages
-						.Concat (requestedPackages)
-						.Any (x => dependency.name == x.name && dependency.version <= x.version);
+                // Is the depended package installed already?
+                bool isInstalled = installedPackages
+                        .Concat(requestedPackages)
+                        .Any(x => dependency.name == x.name && ((dependency.version != null && dependency.version <= x.version) || (dependency.version == null)));
 
 				// Install the depended package later.
 				if (!isInstalled)

--- a/Editor/PackageMeta.cs
+++ b/Editor/PackageMeta.cs
@@ -2,6 +2,7 @@ using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Text.RegularExpressions;
+using UnityEngine;
 
 namespace Coffee.PackageManager.DependencyResolver
 {
@@ -36,16 +37,16 @@ namespace Coffee.PackageManager.DependencyResolver
 					meta.version = obj as string;
 				}
 
-				if (dict.TryGetValue ("dependencies", out obj))
-				{
-					meta.dependencies = (dict ["dependencies"] as Dictionary<string, object>)
-						.Select (x => PackageMeta.FromNameAndUrl (x.Key, (string)x.Value))
-						.ToArray ();
-				}
-				else
-				{
-					meta.dependencies = new PackageMeta [0];
-				}
+                if (dict.TryGetValue("dependencies", out obj))
+                {
+                    meta.dependencies = (dict["dependencies"] as Dictionary<string, object>)
+                        .Select(x => PackageMeta.FromNameAndUrl(x.Key, (string)x.Value))
+                        .ToArray();
+                }
+                else
+                {
+                    meta.dependencies = new PackageMeta[0];
+                }
 				return meta;
 			}
 			catch
@@ -72,8 +73,12 @@ namespace Coffee.PackageManager.DependencyResolver
 				{
 					meta.path = first;
 					meta.branch = 0 < second.Length ? second : "HEAD";
-					meta.version = meta.branch;
-				}
+                    SemVersion version;
+                    if (!SemVersion.TryParse(meta.branch, out version))
+                        version = null;//new SemVersion(0); //empty version
+                    meta.version = version;
+                    //meta.version = meta.branch;
+                }
 				else
 				{
 					meta.version = first;


### PR DESCRIPTION
Support to Non-SemVer Repositories.

**LOGIC BEHIND**
As we cannot compare version of Non-Semver Repo it will only be downloaded if  no other versions of this repo was found

**CASE1:** 
Dependence 1:
repo.git#upm

Dependence 2:
repo.git#1.0.0 <- this will be downloaded instead upm.

**CASE 2:** 
Dependence:
repo.git#upm <- No other repository versions was found, download this repo

**CASE 3:** 
Dependence:
repo.git#upm 

Previous downloaded repo:
repo.git#1.0.5 <- Keep this as we don't know the version of upm before download it



