### PR TITLE
Fix: IOException when temp package files are on different device/partition than Unity project

### DIFF
--- a/Packages/com.coffee.git-dependency-resolver/Editor/DirUtils.cs
+++ b/Packages/com.coffee.git-dependency-resolver/Editor/DirUtils.cs
@@ -30,6 +30,62 @@ namespace Coffee.GitDependencyResolver
                 File.Move(Path.Combine(srcDir, name), Path.Combine(dstDir, name));
         }
 
+        public static void Copy(string srcDir, string dstDir, Func<string, bool> pred = null)
+        {
+            Create(dstDir);
+
+            // Move directories.
+            foreach (var name in Directory.GetDirectories(srcDir)
+                .Select(x => Path.GetFileName(x))
+                .Where(x => pred == null || pred(x)))
+                DirectoryCopy(Path.Combine(srcDir, name), Path.Combine(dstDir, name), true);
+
+            // Move files.
+            DirectoryInfo dir = new DirectoryInfo(srcDir);
+            foreach (FileInfo file in dir.GetFiles()
+                .Where(f => pred == null || pred(f.Name)))
+            {
+                string tempPath = Path.Combine(dstDir, file.Name);
+                file.CopyTo(tempPath, false);
+            }
+        }
+
+        private static void DirectoryCopy(string sourceDirName, string destDirName, bool copySubDirs)
+        {
+            // Get the subdirectories for the specified directory.
+            DirectoryInfo dir = new DirectoryInfo(sourceDirName);
+
+            if (!dir.Exists)
+            {
+                throw new DirectoryNotFoundException(
+                    "Source directory does not exist or could not be found: "
+                    + sourceDirName);
+            }
+
+            DirectoryInfo[] dirs = dir.GetDirectories();
+            
+            // If the destination directory doesn't exist, create it.       
+            Directory.CreateDirectory(destDirName);        
+
+            // Get the files in the directory and copy them to the new location.
+            FileInfo[] files = dir.GetFiles();
+            foreach (FileInfo file in files)
+            {
+                string tempPath = Path.Combine(destDirName, file.Name);
+                file.CopyTo(tempPath, false);
+            }
+
+            // If copying subdirectories, copy them and their contents to new location.
+            if (copySubDirs)
+            {
+                foreach (DirectoryInfo subdir in dirs)
+                {
+                    string tempPath = Path.Combine(destDirName, subdir.Name);
+                    DirectoryCopy(subdir.FullName, tempPath, copySubDirs);
+                }
+            }
+        }
+
         public static void Create(string path)
         {
             if (!Directory.Exists(path))

--- a/Packages/com.coffee.git-dependency-resolver/Editor/GitDependencyResolver.cs
+++ b/Packages/com.coffee.git-dependency-resolver/Editor/GitDependencyResolver.cs
@@ -187,7 +187,8 @@ namespace Coffee.GitDependencyResolver
                     var installPath = "Packages/." + newPackage.GetDirectoryName();
                     DirUtils.Delete(installPath);
                     DirUtils.Create(installPath);
-                    DirUtils.Move(pkgPath, installPath, p => p != ".git");
+                    DirUtils.Copy(pkgPath, installPath, p => p != ".git");
+                    DirUtils.Delete(pkgPath);
 
                     Log("A package '{0}@{1}' has been installed.", package.name, package.version);
                     needToRefresh = true;


### PR DESCRIPTION
---
name: Pull Request
about: Create a pull request
title: 'Fix: IOException when temp package files are on different device/partition than Unity project'
assignees: mob-sakai

---

This pull request aims to fix a bug I encountered while trying to use this package in a Unity project which was on a different partition than my temporary files folder. Since an imported package seems to be copied to the temporary files' folder before being brought back to the actual Unity project's folder, and that I'm on Linux with my `/tmp` folder in a different partition than the rest of my file system, I stumbled upon this error:
```
System.IO.IOException: Source and destination are not on the same device
```
The problem was coming from the package's attempts to **move** the package from the temporary files' folder to the Unity projects, which is not allowed from one partition to another. As such, changing this behavior to simply **copy** the package and then **delete** it from temp folder fixes the problem.
