### PR TITLE
Add locally added packages support for dependency resolver

### DIFF
--- a/Editor/GitDependencyResolver.cs
+++ b/Editor/GitDependencyResolver.cs
@@ -40,7 +40,7 @@ namespace Coffee.GitDependencyResolver
             return Directory.GetDirectories("./Library/PackageCache")
                 .Concat(Directory.GetDirectories("./Packages"))
                 .Select(PackageMeta.FromPackageDir) // Convert to PackageMeta
-                .Concat(new[] {PackageMeta.FromPackageJson("./Packages/manifest.json")})
+                .Concat(PackageMeta.FromManifestJson("./Packages/manifest.json")) // Parses project's manifest.json
                 .Where(x => x != null) // Skip null
                 .ToArray();
         }

--- a/Editor/PackageMeta.cs
+++ b/Editor/PackageMeta.cs
@@ -56,6 +56,12 @@ namespace Coffee.GitDependencyResolver
                 @"(git@|git://|http://|https://|ssh://)",
                 k_RegOption);
 
+        private static readonly Regex s_IsFileReg = 
+           new Regex(
+               @"^(file:)" +
+               @"(?<path>.*)",
+               k_RegOption);
+
         private static readonly GitLock s_GitLock = new GitLock();
 
         public string name { get; private set; }
@@ -180,6 +186,13 @@ namespace Coffee.GitDependencyResolver
         public static PackageMeta FromNameAndUrl(string name, string url)
         {
             PackageMeta package = new PackageMeta() {name = name};
+
+            // Local file package.
+            Match f = s_IsFileReg.Match(url);
+            if (f.Success) {
+                string path = f.Groups["path"].Value; // Absolute path to package
+                return FromPackageDir(path); // Treat the package from its package dir
+            }
 
             // Non git package.
             var isGit = s_IsGitReg.IsMatch(url);

--- a/Editor/PackageMeta.cs
+++ b/Editor/PackageMeta.cs
@@ -137,6 +137,37 @@ namespace Coffee.GitDependencyResolver
             }
         }
 
+        public static PackageMeta[] FromManifestJson(string filePath)
+        {
+            try
+            {
+                if (!File.Exists(filePath))
+                {
+                    return null;
+                }
+
+                Dictionary<string, object> dict = Json.Deserialize(File.ReadAllText(filePath)) as Dictionary<string, object>;
+
+                object obj;
+
+                PackageMeta[] ans = new PackageMeta[0];
+
+                if (dict.TryGetValue("dependencies", out obj)) // if there is any dependencies field
+                {
+                    // parses all packages listed in the manifest.json in a packages array
+                    ans = (obj as Dictionary<string, object>)
+                        .Select(x => FromNameAndUrl(x.Key, (string) x.Value))
+                        .ToArray();
+                }
+
+                return ans;
+            }
+            catch
+            {
+                return null;
+            }
+        }
+
         public static PackageMeta FromPackageDir(string dir)
         {
             var package = FromPackageJson(dir + "/package.json");


### PR DESCRIPTION
---
name: Pull Request
about: Create a pull request
title: 'Add local file packages processing'
assignees: mob-sakai

---

This PR aims to add support for __locally added packages__ (added in UPM with the `Add package from disk` option). They are listed in a project's `manifest.json` file with URIs following the file scheme (example: `file:/path/to/my/package/folder`, as defined in [RFC 8089](https://tools.ietf.org/html/rfc8089)).

Those packages used to be silently ignored by the Git Dependency Resolver, as their own dependencies (and, in the end, git dependencies) wouldn't be parsed at all.

I tried to solve this problem by:
* Adding a specific method to parse a `manifest.json` project file (instead of trying to parse it like a common `package.json` file)
* Adding recognition for file URI scheme
* Parsing installed local packages respective `package.json` file to list the dependencies