### PR TITLE
feat: allow resolve dependencies for packages at relative path of the project

### DIFF
--- a/Editor/GitDependencyResolver.cs
+++ b/Editor/GitDependencyResolver.cs
@@ -37,10 +37,12 @@ namespace Coffee.GitDependencyResolver
 
         private static PackageMeta[] GetInstalledPackages()
         {
+            var manifestJsonPackageMeta = PackageMeta.FromPackageJson("./Packages/manifest.json");
             return Directory.GetDirectories("./Library/PackageCache")
                 .Concat(Directory.GetDirectories("./Packages"))
                 .Select(PackageMeta.FromPackageDir) // Convert to PackageMeta
-                .Concat(new[] {PackageMeta.FromPackageJson("./Packages/manifest.json")})
+                .Concat(new[] {manifestJsonPackageMeta})
+                .Concat(manifestJsonPackageMeta.GetRelativePackages())
                 .Where(x => x != null) // Skip null
                 .ToArray();
         }

--- a/Editor/PackageMeta.cs
+++ b/Editor/PackageMeta.cs
@@ -55,6 +55,8 @@ namespace Coffee.GitDependencyResolver
                 @"^(git\\+)?" +
                 @"(git@|git://|http://|https://|ssh://)",
                 k_RegOption);
+        
+        private const string k_RelativeFilePrefix = "file:../";
 
         private static readonly GitLock s_GitLock = new GitLock();
 
@@ -86,9 +88,7 @@ namespace Coffee.GitDependencyResolver
             try
             {
                 if (!File.Exists(filePath))
-                {
                     return null;
-                }
 
                 string dir = Path.GetDirectoryName(filePath);
                 Dictionary<string, object> dict = Json.Deserialize(File.ReadAllText(filePath)) as Dictionary<string, object>;
@@ -154,7 +154,14 @@ namespace Coffee.GitDependencyResolver
             var isGit = s_IsGitReg.IsMatch(url);
             if (!isGit)
             {
-                package.SetVersion(url);
+                if (url.StartsWith(k_RelativeFilePrefix))
+                {
+                    package.SetPath(url);
+                }
+                else
+                {
+                    package.SetVersion(url);
+                }
                 return package;
             }
 
@@ -188,6 +195,11 @@ namespace Coffee.GitDependencyResolver
                 version = v;
         }
 
+        private void SetPath(string relativePath)
+        {
+            path = relativePath;
+        }
+
         private void ProcessUrlQuery(string urlQuery)
         {
             // Process url query.
@@ -213,6 +225,13 @@ namespace Coffee.GitDependencyResolver
         public IEnumerable<PackageMeta> GetAllDependencies()
         {
             return gitDependencies.Concat(dependencies);
+        }
+
+        public IEnumerable<PackageMeta> GetRelativePackages()
+        {
+            return dependencies.Where(dependency => dependency.path.StartsWith(k_RelativeFilePrefix))
+                .Select(dependency => Path.GetFullPath(dependency.path[k_RelativeFilePrefix.Length..]))
+                .Select(FromPackageDir);
         }
 
         public string GetDirectoryName()

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
 	"name": "com.coffee.git-dependency-resolver",
 	"displayName": "Git Dependency Resolver",
 	"description": "This plugin resolves git dependencies in the package for Unity Package Manager.\nYou can use a git url as a package dependency!",
-	"version": "2.0.0",
+	"version": "2.0.1",
 	"unity": "2018.3",
 	"license": "MIT",
 	"repository": {


### PR DESCRIPTION
Something I noticed is that, if I define a relative path package `"com.my.package": "file:../../com.my.package" then its gitDependencies are not processed to import. This PR fixes that by handling the special case of the path "file:.." prefix.